### PR TITLE
修正使用HTTPS時，頁面載入失敗的問題 Fix page loading failure when viewing page via HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <title>Emma</title>
   <link rel="SHORTCUT ICON" href="./img/favicon.png"/>
-  <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap-theme.min.css">
-  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <link href="http://fonts.googleapis.com/css?family=Raleway:400,800" rel="stylesheet" type="text/css">
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap-theme.min.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link href="//fonts.googleapis.com/css?family=Raleway:400,800" rel="stylesheet" type="text/css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
   <script src="./js/jquery.lazyload.min.js"></script>
 
   <link rel="stylesheet" href="./css/page.css">


### PR DESCRIPTION
使用HTTPS連到 https://emma2334.github.io 時，頁面載入會失敗，永遠卡在動畫部份，因為Firefox/Chromium等瀏覽器會擋掉你使用HTTP載入的外部 js 檔案。這個PR應該可以修正...吧（我的GitHub Page也遇過類似狀況），因為我clone下來後不太清楚該怎麼測試，直接用瀏覽器打開`index.html`都只會顯示載入失敗請重新整理。對前端不太熟，不知道該怎麼開這玩意。

---

因為有點興奮所以題外話閒聊一下，我在學校時還刻意跑到資工系修課卻都沒找到有誰有在用GitHub或參與FLOSS社群的同好，沒想到畢業後，在GitHub上找dm5 downloader竟然誤打誤撞發現同校的，真是太驚喜了。

看到網站內容有Rails Girls...該不會你今年有修過資料庫吧？（看到課堂上有人的筆電上有Rails Girls貼紙）

還有，因為想學一下前端，想請問你這網站JS是純手刻嗎？如果是的話...看了一下`js/page.js`竟然只用JQuery寫這個感覺好痛苦啊orz（潔癖，很抗拒在JS裡面寫太多html）
